### PR TITLE
fix: Fixed an error that occurred when the timer continued to run without pausing

### DIFF
--- a/lib/services/pomodoro_service.dart
+++ b/lib/services/pomodoro_service.dart
@@ -62,6 +62,8 @@ class TimerService with WidgetsBindingObserver {
   void switchTimer() {
     if (isPomodoro) {
       duration = breakDuration;
+      elapsedTimeForFirestore = 0; // Firestore 용 경과 시간 초기화
+      elapsedTimeForUI = 0;        // UI 표시 용 경과 시간 초기화
     } else {
       duration = pomodoroDuration;
     }


### PR DESCRIPTION
 firebase에 시간 저장하는 부분은 이상이 없었는데, 시간을 출력하는 부분에서 오류가 있었습니다. 
 해 당 오류는 수정 완료했습니다.