### PR TITLE
fix: adjust container width to maximum in bookDetailScreen

### DIFF
--- a/lib/screens/book_detail_screen.dart
+++ b/lib/screens/book_detail_screen.dart
@@ -339,6 +339,7 @@ class _BookDetailScreenState extends State<BookDetailScreen> {
                 const SizedBox(height: 25),
 
                 Container(
+                  width: double.infinity,
                   decoration: BoxDecoration(
                       border: Border(
                           bottom: BorderSide(


### PR DESCRIPTION
도서 상세 페이지에서 도서 제목과 본문의 구분선이 잘려 보이는 문제를 수정하였습니다.