### PR TITLE
fix: Fix bugs that reset book selection status

### DIFF
--- a/lib/components/timer/timer_pomodoro.dart
+++ b/lib/components/timer/timer_pomodoro.dart
@@ -25,7 +25,10 @@ class PomodoroPage extends StatefulWidget {
   _PomodoroPageState createState() => _PomodoroPageState();
 }
 
-class _PomodoroPageState extends State<PomodoroPage> {
+class _PomodoroPageState extends State<PomodoroPage> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true; // 상태 유지 활성화
+
   final BookReadingTimeService _readingTimeService = BookReadingTimeService();
   final DailyReadingService _dailyReadingService = DailyReadingService();
   String elapsedTimeText = '';

--- a/lib/components/timer/timer_stopwatch.dart
+++ b/lib/components/timer/timer_stopwatch.dart
@@ -23,7 +23,10 @@ class StopwatchPage extends StatefulWidget {
   _StopwatchPageState createState() => _StopwatchPageState();
 }
 
-class _StopwatchPageState extends State<StopwatchPage> {
+class _StopwatchPageState extends State<StopwatchPage> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true; // 상태 유지 활성화
+
   final BookReadingTimeService _readingTimeService = BookReadingTimeService();
   String elapsedTimeText = '00:00';
   Map<String, String>? selectedBook;


### PR DESCRIPTION
스탑워치 페이지에서 책 선택하고 뽀모도로 페이지로 넘어온 후, 다시 스탑워치 페이지로 넘어오면 책 선택했던 상태 초기화 되던 버그 수정했습니다.